### PR TITLE
Make Pomodoro timer window resizable and minimizable with persisted geometry

### DIFF
--- a/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro.csproj
+++ b/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro.csproj
@@ -13,7 +13,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Community.PowerToys.Run.Plugin.Dependencies" Version="0.90.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />

--- a/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/PomodoroResultWindow.xaml
+++ b/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/PomodoroResultWindow.xaml
@@ -160,26 +160,6 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <!-- Window Controls (Top Right) - Windows 11 Style -->
-                <StackPanel Orientation="Horizontal"
-                            HorizontalAlignment="Right"
-                            VerticalAlignment="Top">
-                    <Button Content="−"
-                            Style="{StaticResource Win11Button}"
-                            Padding="10,2"
-                            FontSize="12"
-                            ToolTip="Minimize"
-                            Click="MinimizeButton_Click"
-                            Background="Transparent"/>
-                    <Button Content="✕"
-                            Style="{StaticResource Win11Button}"
-                            Padding="10,2"
-                            FontSize="12"
-                            ToolTip="Close"
-                            Click="CloseButton_Click"
-                            Background="Transparent"/>
-                </StackPanel>
-
                 <!-- Tomato Image Added -->
                 <Image x:Name="StaticBallImage"
                        Grid.Row="1" 
@@ -272,6 +252,30 @@
                 </StackPanel>
             </Grid>
             </Viewbox>
+
+            <!-- Window Controls (Top Right) - Windows 11 Style.
+                 Kept outside the Viewbox so they stay anchored to the window's
+                 top-right corner and don't move when the window is resized. -->
+            <StackPanel Orientation="Horizontal"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Top"
+                        Panel.ZIndex="1"
+                        Margin="0,8,8,0">
+                <Button Content="−"
+                        Style="{StaticResource Win11Button}"
+                        Padding="10,2"
+                        FontSize="12"
+                        ToolTip="Minimize"
+                        Click="MinimizeButton_Click"
+                        Background="Transparent"/>
+                <Button Content="✕"
+                        Style="{StaticResource Win11Button}"
+                        Padding="10,2"
+                        FontSize="12"
+                        ToolTip="Close"
+                        Click="CloseButton_Click"
+                        Background="Transparent"/>
+            </StackPanel>
         </Grid>
     </Border>
 

--- a/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/PomodoroResultWindow.xaml
+++ b/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/PomodoroResultWindow.xaml
@@ -8,8 +8,10 @@
         Title="Pomodoro Timer" 
         Height="380" 
         Width="380"
+        MinHeight="220"
+        MinWidth="220"
         WindowStartupLocation="CenterScreen"
-        ResizeMode="NoResize"
+        ResizeMode="CanResizeWithGrip"
         ShowInTaskbar="True"
         Topmost="True"
         Background="Transparent"
@@ -144,6 +146,8 @@
                 </Border.Background>
             </Border>
 
+            <!-- Main content scales with the window via Viewbox -->
+            <Viewbox Stretch="Uniform" StretchDirection="Both">
             <!-- Main Layout Grid -->
             <Grid Margin="20">
                 <Grid.RowDefinitions>
@@ -156,15 +160,25 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <!-- Close Button (Top Right) - Windows 11 Style -->
-                <Button Content="✕" 
-                        Style="{StaticResource Win11Button}"
-                        HorizontalAlignment="Right" 
-                        VerticalAlignment="Top" 
-                        Padding="10,2"
-                        FontSize="12"
-                        Click="CloseButton_Click"
-                        Background="Transparent"/>
+                <!-- Window Controls (Top Right) - Windows 11 Style -->
+                <StackPanel Orientation="Horizontal"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Top">
+                    <Button Content="&#x2013;"
+                            Style="{StaticResource Win11Button}"
+                            Padding="10,2"
+                            FontSize="12"
+                            ToolTip="Minimize"
+                            Click="MinimizeButton_Click"
+                            Background="Transparent"/>
+                    <Button Content="&#x2715;"
+                            Style="{StaticResource Win11Button}"
+                            Padding="10,2"
+                            FontSize="12"
+                            ToolTip="Close"
+                            Click="CloseButton_Click"
+                            Background="Transparent"/>
+                </StackPanel>
 
                 <!-- Tomato Image Added -->
                 <Image x:Name="StaticBallImage"
@@ -257,6 +271,7 @@
                             Click="BtnStop_Click"/>
                 </StackPanel>
             </Grid>
+            </Viewbox>
         </Grid>
     </Border>
 

--- a/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/PomodoroResultWindow.xaml
+++ b/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/PomodoroResultWindow.xaml
@@ -164,14 +164,14 @@
                 <StackPanel Orientation="Horizontal"
                             HorizontalAlignment="Right"
                             VerticalAlignment="Top">
-                    <Button Content="&#x2013;"
+                    <Button Content="−"
                             Style="{StaticResource Win11Button}"
                             Padding="10,2"
                             FontSize="12"
                             ToolTip="Minimize"
                             Click="MinimizeButton_Click"
                             Background="Transparent"/>
-                    <Button Content="&#x2715;"
+                    <Button Content="✕"
                             Style="{StaticResource Win11Button}"
                             Padding="10,2"
                             FontSize="12"

--- a/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/PomodoroResultWindow.xaml.cs
+++ b/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/PomodoroResultWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Reflection;
+using System.Text.Json;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -690,7 +691,7 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
                     return;
                 }
 
-                var state = Newtonsoft.Json.JsonConvert.DeserializeObject<WindowGeometry>(File.ReadAllText(path));
+                var state = JsonSerializer.Deserialize<WindowGeometry>(File.ReadAllText(path));
                 if (state == null || state.Width <= 0 || state.Height <= 0)
                 {
                     return;
@@ -754,7 +755,7 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
                     Height = bounds.Height,
                 };
 
-                File.WriteAllText(GetWindowStateFilePath(), Newtonsoft.Json.JsonConvert.SerializeObject(state));
+                File.WriteAllText(GetWindowStateFilePath(), JsonSerializer.Serialize(state));
             }
             catch (Exception ex)
             {

--- a/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/PomodoroResultWindow.xaml.cs
+++ b/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/PomodoroResultWindow.xaml.cs
@@ -197,6 +197,7 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
 
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {
+            RestoreWindowGeometry();
             LoadStaticImage();
             ApplyWindowTransparency();
         }
@@ -630,6 +631,18 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
             BtnStop_Click(sender, e);
         }
 
+        private void MinimizeButton_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                WindowState = WindowState.Minimized;
+            }
+            catch (Exception ex)
+            {
+                Log.Exception("Error minimizing window", ex, GetType());
+            }
+        }
+
         private void Border_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
             if (!_isClosing && e.ChangedButton == MouseButton.Left)
@@ -648,8 +661,120 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
         private void PomodoroResultWindow_Closing(object? sender, CancelEventArgs e)
         {
             _isClosing = true;
+            SaveWindowGeometry();
             _timer.Stop();
         }
+
+        /// <summary>
+        /// Gets the path to the file used to persist the timer window size and position.
+        /// </summary>
+        private static string GetWindowStateFilePath()
+        {
+            string dir = System.IO.Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "PowerToysRun-Pomodoro");
+            Directory.CreateDirectory(dir);
+            return System.IO.Path.Combine(dir, "window-state.json");
+        }
+
+        /// <summary>
+        /// Restores the previously persisted window size and position, if any.
+        /// </summary>
+        private void RestoreWindowGeometry()
+        {
+            try
+            {
+                string path = GetWindowStateFilePath();
+                if (!File.Exists(path))
+                {
+                    return;
+                }
+
+                var state = Newtonsoft.Json.JsonConvert.DeserializeObject<WindowGeometry>(File.ReadAllText(path));
+                if (state == null || state.Width <= 0 || state.Height <= 0)
+                {
+                    return;
+                }
+
+                // Clamp the size to the window's configured minimum.
+                double width = Math.Max(state.Width, MinWidth);
+                double height = Math.Max(state.Height, MinHeight);
+
+                // Ensure the saved position is visible on the current virtual screen
+                // before applying it, so the window can never open off-screen.
+                double virtualLeft = SystemParameters.VirtualScreenLeft;
+                double virtualTop = SystemParameters.VirtualScreenTop;
+                double virtualRight = virtualLeft + SystemParameters.VirtualScreenWidth;
+                double virtualBottom = virtualTop + SystemParameters.VirtualScreenHeight;
+
+                bool onScreen = state.Left + width > virtualLeft
+                    && state.Left < virtualRight
+                    && state.Top + height > virtualTop
+                    && state.Top < virtualBottom;
+
+                Width = width;
+                Height = height;
+
+                if (onScreen)
+                {
+                    WindowStartupLocation = WindowStartupLocation.Manual;
+                    Left = state.Left;
+                    Top = state.Top;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Exception("Error restoring window geometry", ex, GetType());
+            }
+        }
+
+        /// <summary>
+        /// Persists the current window size and position for the next session.
+        /// </summary>
+        private void SaveWindowGeometry()
+        {
+            try
+            {
+                // Use RestoreBounds so a minimized/maximized window still saves its
+                // normal size and position rather than the transient state values.
+                Rect bounds = WindowState == WindowState.Normal
+                    ? new Rect(Left, Top, Width, Height)
+                    : RestoreBounds;
+
+                if (bounds.IsEmpty || bounds.Width <= 0 || bounds.Height <= 0)
+                {
+                    return;
+                }
+
+                var state = new WindowGeometry
+                {
+                    Left = bounds.Left,
+                    Top = bounds.Top,
+                    Width = bounds.Width,
+                    Height = bounds.Height,
+                };
+
+                File.WriteAllText(GetWindowStateFilePath(), Newtonsoft.Json.JsonConvert.SerializeObject(state));
+            }
+            catch (Exception ex)
+            {
+                Log.Exception("Error saving window geometry", ex, GetType());
+            }
+        }
+    }
+
+    /// <summary>
+    /// Serializable size and position of the Pomodoro timer window.
+    /// </summary>
+    internal sealed class WindowGeometry
+    {
+        public double Left { get; set; }
+
+        public double Top { get; set; }
+
+        public double Width { get; set; }
+
+        public double Height { get; set; }
     }
 
     // ProgressBar width converter needed for the custom style

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Pomodoro is a plugin for [Microsoft PowerToys Run](https://github.com/microsoft/
 - 🔔 **End-of-Session Alerts** - Get notified when your session ends with sound or visual cues
 - 🌙 **Break Management** - Automatically switch between work sessions and breaks
 - ⚙️ **Configurable Session Length** - Customize work and break durations to fit your workflow
+- 🪟 **Resizable & Minimizable Timer Window** - Resize the timer window with the corner grip, minimize it to the taskbar, and it remembers your preferred size and position between sessions
 
 ## 🎬 Demo Gallery
 


### PR DESCRIPTION
The running timer window was a fixed-size, borderless popup with no way to resize or minimize it. This adds user-controlled resizing, a minimize button, and persistence of the window's size/position across sessions — without altering the existing semi-transparent design or manual drag behavior.

### Window chrome (`PomodoroResultWindow.xaml`)
- `ResizeMode` → `CanResizeWithGrip`, with `MinWidth`/`MinHeight` of 220×220 (default remains 380×380). Works alongside the borderless `WindowStyle="None"` + `AllowsTransparency="True"` setup.
- Content wrapped in a `Viewbox` (`Stretch="Uniform"`) so all elements scale proportionally with the window.
- Added a `−` minimize button beside the existing `✕` close button.

### Behavior (`PomodoroResultWindow.xaml.cs`)
- `MinimizeButton_Click` sets `WindowState = Minimized`; the window already sets `ShowInTaskbar="True"`, so it restores from the taskbar.
- Geometry (Left/Top/Width/Height) is persisted to `%LOCALAPPDATA%\PowerToysRun-Pomodoro\window-state.json` on close and restored on load. Restore clamps to the minimum size and validates against the virtual screen so the window can't open off-screen; save uses `RestoreBounds` to capture the normal geometry even when minimized/maximized.

### Docs
- README Features updated to note the resizable/minimizable/persisted window.

Note: interactive behavior (resize/minimize/persistence) is verified locally on ARM 64 machine. 