### PR TITLE
feat: Media control + CLI hooks on timer events

### DIFF
--- a/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro.UnitTests/MainTests.cs
+++ b/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro.UnitTests/MainTests.cs
@@ -1,5 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
+using Community.PowerToys.Run.Plugin.Pomodoro.Models;
+using Community.PowerToys.Run.Plugin.Pomodoro.Services;
 using Wox.Plugin;
 
 namespace Community.PowerToys.Run.Plugin.Pomodoro.UnitTests
@@ -19,7 +21,6 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro.UnitTests
         public void Query_should_return_results()
         {
             var results = main.Query(new("search"));
-
             Assert.IsNotNull(results.First());
         }
 
@@ -27,8 +28,82 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro.UnitTests
         public void LoadContextMenus_should_return_results()
         {
             var results = main.LoadContextMenus(new Result { ContextData = "search" });
-
             Assert.IsNotNull(results.First());
+        }
+
+        [TestMethod]
+        public void Plugin_should_have_correct_id()
+        {
+            Assert.AreEqual("6884550EBA0A4A82B090AA19C01F9B38", Main.PluginID);
+        }
+
+        [TestMethod]
+        public void AdditionalOptions_should_include_media_and_hook_settings()
+        {
+            var options = main.AdditionalOptions.ToList();
+
+            // Media control options
+            Assert.IsTrue(options.Any(o => o.Key == nameof(Main.MediaPlayOnSessionStart)),
+                "MediaPlayOnSessionStart option should be present");
+            Assert.IsTrue(options.Any(o => o.Key == nameof(Main.MediaPauseOnSessionEnd)),
+                "MediaPauseOnSessionEnd option should be present");
+
+            // CLI hook options
+            Assert.IsTrue(options.Any(o => o.Key == nameof(Main.HookOnPomodoroStart)),
+                "HookOnPomodoroStart option should be present");
+            Assert.IsTrue(options.Any(o => o.Key == nameof(Main.HookOnPomodoroEnd)),
+                "HookOnPomodoroEnd option should be present");
+            Assert.IsTrue(options.Any(o => o.Key == nameof(Main.HookOnBreakStart)),
+                "HookOnBreakStart option should be present");
+            Assert.IsTrue(options.Any(o => o.Key == nameof(Main.HookOnBreakEnd)),
+                "HookOnBreakEnd option should be present");
+            Assert.IsTrue(options.Any(o => o.Key == nameof(Main.HookOnPause)),
+                "HookOnPause option should be present");
+            Assert.IsTrue(options.Any(o => o.Key == nameof(Main.HookOnResume)),
+                "HookOnResume option should be present");
+            Assert.IsTrue(options.Any(o => o.Key == nameof(Main.HookOnStop)),
+                "HookOnStop option should be present");
+        }
+    }
+
+    [TestClass]
+    public class PomodoroEventTests
+    {
+        [TestMethod]
+        public void PomodoroEvent_should_default_empty()
+        {
+            var evt = new PomodoroEvent();
+            Assert.AreEqual(string.Empty, evt.EventName);
+            Assert.AreEqual(string.Empty, evt.SessionType);
+            Assert.AreEqual(0, evt.LengthMinutes);
+        }
+
+        [TestMethod]
+        public void PomodoroEvent_should_set_properties()
+        {
+            var evt = new PomodoroEvent
+            {
+                EventName = "start",
+                SessionType = "Pomodoro",
+                LengthMinutes = 25
+            };
+
+            Assert.AreEqual("start", evt.EventName);
+            Assert.AreEqual("Pomodoro", evt.SessionType);
+            Assert.AreEqual(25, evt.LengthMinutes);
+        }
+    }
+
+    [TestClass]
+    public class HookServiceTests
+    {
+        [TestMethod]
+        public void ExecuteHook_empty_command_should_not_throw()
+        {
+            var svc = new HookService(typeof(HookServiceTests));
+            svc.ExecuteHook("", new PomodoroEvent());
+            svc.ExecuteHook(null, new PomodoroEvent());
+            svc.ExecuteHook("   ", new PomodoroEvent());
         }
     }
 }

--- a/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/Main.cs
+++ b/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/Main.cs
@@ -38,10 +38,25 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
 
         // New properties for enhanced features
         private SoundService? SoundService { get; set; }
+        private MediaControlService? MediaService { get; set; }
+        private HookService? Hooks { get; set; }
         public bool PlaySounds { get; private set; } = true;
         public bool AutoStartNextSession { get; private set; } = false;
         public int PomodorosBeforeLongBreak { get; private set; } = 4;
         private int CurrentPomodoroCount { get; set; } = 0;
+
+        // Media control settings
+        public bool MediaPlayOnSessionStart { get; private set; } = false;
+        public bool MediaPauseOnSessionEnd { get; private set; } = false;
+
+        // CLI hook settings
+        public string HookOnPomodoroStart { get; private set; } = string.Empty;
+        public string HookOnPomodoroEnd { get; private set; } = string.Empty;
+        public string HookOnBreakStart { get; private set; } = string.Empty;
+        public string HookOnBreakEnd { get; private set; } = string.Empty;
+        public string HookOnPause { get; private set; } = string.Empty;
+        public string HookOnResume { get; private set; } = string.Empty;
+        public string HookOnStop { get; private set; } = string.Empty;
 
         /// <summary>
         /// Exposes additional plugin settings in the PowerToys Settings UI.
@@ -103,6 +118,80 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
                 DisplayDescription = "Number of work phases before taking a long break",
                 PluginOptionType = PluginAdditionalOption.AdditionalOptionType.Textbox,
                 TextValue = PomodorosBeforeLongBreak.ToString()
+            },
+            // ─── Media Control ───
+            new PluginAdditionalOption
+            {
+                Key = nameof(MediaPlayOnSessionStart),
+                DisplayLabel = "▶ Play media on session start",
+                DisplayDescription = "Toggle play/pause on media (Spotify, YouTube, etc.) when a focus session starts",
+                PluginOptionType = PluginAdditionalOption.AdditionalOptionType.Checkbox,
+                Value = MediaPlayOnSessionStart
+            },
+            new PluginAdditionalOption
+            {
+                Key = nameof(MediaPauseOnSessionEnd),
+                DisplayLabel = "⏸ Pause media on session end",
+                DisplayDescription = "Toggle play/pause on media when a focus session ends",
+                PluginOptionType = PluginAdditionalOption.AdditionalOptionType.Checkbox,
+                Value = MediaPauseOnSessionEnd
+            },
+            // ─── CLI Hooks ───
+            new PluginAdditionalOption
+            {
+                Key = nameof(HookOnPomodoroStart),
+                DisplayLabel = "On Pomodoro start — command",
+                DisplayDescription = "CLI command to run when a Pomodoro starts. Tokens: {event} {type} {minutes}",
+                PluginOptionType = PluginAdditionalOption.AdditionalOptionType.Textbox,
+                TextValue = HookOnPomodoroStart
+            },
+            new PluginAdditionalOption
+            {
+                Key = nameof(HookOnPomodoroEnd),
+                DisplayLabel = "On Pomodoro end — command",
+                DisplayDescription = "CLI command to run when a Pomodoro ends. Tokens: {event} {type} {minutes}",
+                PluginOptionType = PluginAdditionalOption.AdditionalOptionType.Textbox,
+                TextValue = HookOnPomodoroEnd
+            },
+            new PluginAdditionalOption
+            {
+                Key = nameof(HookOnBreakStart),
+                DisplayLabel = "On break start — command",
+                DisplayDescription = "CLI command to run when any break starts. Tokens: {event} {type} {minutes}",
+                PluginOptionType = PluginAdditionalOption.AdditionalOptionType.Textbox,
+                TextValue = HookOnBreakStart
+            },
+            new PluginAdditionalOption
+            {
+                Key = nameof(HookOnBreakEnd),
+                DisplayLabel = "On break end — command",
+                DisplayDescription = "CLI command to run when any break ends. Tokens: {event} {type} {minutes}",
+                PluginOptionType = PluginAdditionalOption.AdditionalOptionType.Textbox,
+                TextValue = HookOnBreakEnd
+            },
+            new PluginAdditionalOption
+            {
+                Key = nameof(HookOnPause),
+                DisplayLabel = "On pause — command",
+                DisplayDescription = "CLI command to run when the timer is paused. Tokens: {event} {type} {minutes}",
+                PluginOptionType = PluginAdditionalOption.AdditionalOptionType.Textbox,
+                TextValue = HookOnPause
+            },
+            new PluginAdditionalOption
+            {
+                Key = nameof(HookOnResume),
+                DisplayLabel = "On resume — command",
+                DisplayDescription = "CLI command to run when the timer is resumed. Tokens: {event} {type} {minutes}",
+                PluginOptionType = PluginAdditionalOption.AdditionalOptionType.Textbox,
+                TextValue = HookOnResume
+            },
+            new PluginAdditionalOption
+            {
+                Key = nameof(HookOnStop),
+                DisplayLabel = "On stop — command",
+                DisplayDescription = "CLI command to run when the timer is manually stopped. Tokens: {event} {type} {minutes}",
+                PluginOptionType = PluginAdditionalOption.AdditionalOptionType.Textbox,
+                TextValue = HookOnStop
             }
         };
 
@@ -134,6 +223,12 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
 
             // Initialize the sound service
             SoundService = new SoundService(GetType());
+
+            // Initialize media control service
+            MediaService = new MediaControlService(GetType());
+
+            // Initialize hook service
+            Hooks = new HookService(GetType());
 
             // Initialize API service
             ApiService = new TickCounterApiService(GetType());
@@ -271,6 +366,68 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
         }
 
         /// <summary>
+        /// Triggers media control and CLI hooks for a given Pomodoro event.
+        /// Called from all session lifecycle points (start, end, pause, resume, stop).
+        /// </summary>
+        /// <param name="eventName">The event name: "start", "end", "pause", "resume", or "stop".</param>
+        /// <param name="sessionType">The session type (Pomodoro, Short Break, Long Break).</param>
+        /// <param name="lengthMinutes">The session length in minutes.</param>
+        private void TriggerEvent(string eventName, string sessionType, int lengthMinutes)
+        {
+            try
+            {
+                var evt = new PomodoroEvent
+                {
+                    EventName = eventName,
+                    SessionType = sessionType,
+                    LengthMinutes = lengthMinutes
+                };
+
+                // ─── Media control ───
+                bool isBreak = sessionType == "Short Break" || sessionType == "Long Break";
+
+                if (eventName == "start")
+                {
+                    // Play media when a Pomodoro (focus) session starts
+                    if (MediaPlayOnSessionStart && !isBreak)
+                    {
+                        MediaService?.TogglePlayPause();
+                    }
+                }
+                else if (eventName == "end")
+                {
+                    // Pause media when a Pomodoro (focus) session ends
+                    if (MediaPauseOnSessionEnd && !isBreak)
+                    {
+                        MediaService?.TogglePlayPause();
+                    }
+                }
+
+                // ─── CLI hooks ───
+                string? hookCommand = eventName switch
+                {
+                    "start" when isBreak => HookOnBreakStart,
+                    "start" => HookOnPomodoroStart,
+                    "end" when isBreak => HookOnBreakEnd,
+                    "end" => HookOnPomodoroEnd,
+                    "pause" => HookOnPause,
+                    "resume" => HookOnResume,
+                    "stop" => HookOnStop,
+                    _ => null
+                };
+
+                if (!string.IsNullOrWhiteSpace(hookCommand))
+                {
+                    Hooks?.ExecuteHook(hookCommand, evt);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Exception($"Error triggering event {eventName}", ex, GetType());
+            }
+        }
+
+        /// <summary>
         /// Handle timer completion and potentially start the next phase
         /// </summary>
         /// <param name="session">The completed session</param>
@@ -278,6 +435,9 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
         {
             try
             {
+                // Trigger media control and hooks for "end" event
+                TriggerEvent("end", session.Type, session.LengthMinutes);
+
                 // Play sound immediately when timer completes
                 if (PlaySounds)
                 {
@@ -405,6 +565,28 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
                 pomodoroSettings.PomodorosBeforeLongBreak = pomodorosBeforeLongBreak;
             }
 
+            // ─── Media control settings ───
+            pomodoroSettings.MediaPlayOnSessionStart = settings.AdditionalOptions
+                .SingleOrDefault(x => x.Key == nameof(MediaPlayOnSessionStart))?.Value ?? pomodoroSettings.MediaPlayOnSessionStart;
+            pomodoroSettings.MediaPauseOnSessionEnd = settings.AdditionalOptions
+                .SingleOrDefault(x => x.Key == nameof(MediaPauseOnSessionEnd))?.Value ?? pomodoroSettings.MediaPauseOnSessionEnd;
+
+            // ─── CLI hook settings ───
+            pomodoroSettings.HookOnPomodoroStart = settings.AdditionalOptions
+                .SingleOrDefault(x => x.Key == nameof(HookOnPomodoroStart))?.TextValue ?? string.Empty;
+            pomodoroSettings.HookOnPomodoroEnd = settings.AdditionalOptions
+                .SingleOrDefault(x => x.Key == nameof(HookOnPomodoroEnd))?.TextValue ?? string.Empty;
+            pomodoroSettings.HookOnBreakStart = settings.AdditionalOptions
+                .SingleOrDefault(x => x.Key == nameof(HookOnBreakStart))?.TextValue ?? string.Empty;
+            pomodoroSettings.HookOnBreakEnd = settings.AdditionalOptions
+                .SingleOrDefault(x => x.Key == nameof(HookOnBreakEnd))?.TextValue ?? string.Empty;
+            pomodoroSettings.HookOnPause = settings.AdditionalOptions
+                .SingleOrDefault(x => x.Key == nameof(HookOnPause))?.TextValue ?? string.Empty;
+            pomodoroSettings.HookOnResume = settings.AdditionalOptions
+                .SingleOrDefault(x => x.Key == nameof(HookOnResume))?.TextValue ?? string.Empty;
+            pomodoroSettings.HookOnStop = settings.AdditionalOptions
+                .SingleOrDefault(x => x.Key == nameof(HookOnStop))?.TextValue ?? string.Empty;
+
             // Тепер оновлюємо поля в Main, щоб використовувати нові значення
             ShowNotifications = pomodoroSettings.ShowNotifications;
             PomodoroLength = pomodoroSettings.PomodoroLength;
@@ -413,6 +595,19 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
             PlaySounds = pomodoroSettings.PlaySounds;
             AutoStartNextSession = pomodoroSettings.AutoStartNextSession;
             PomodorosBeforeLongBreak = pomodoroSettings.PomodorosBeforeLongBreak;
+
+            // Media control
+            MediaPlayOnSessionStart = pomodoroSettings.MediaPlayOnSessionStart;
+            MediaPauseOnSessionEnd = pomodoroSettings.MediaPauseOnSessionEnd;
+
+            // CLI hooks
+            HookOnPomodoroStart = pomodoroSettings.HookOnPomodoroStart;
+            HookOnPomodoroEnd = pomodoroSettings.HookOnPomodoroEnd;
+            HookOnBreakStart = pomodoroSettings.HookOnBreakStart;
+            HookOnBreakEnd = pomodoroSettings.HookOnBreakEnd;
+            HookOnPause = pomodoroSettings.HookOnPause;
+            HookOnResume = pomodoroSettings.HookOnResume;
+            HookOnStop = pomodoroSettings.HookOnStop;
         }
 
         /// <inheritdoc/>
@@ -481,6 +676,9 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
                     length = customLength;
                 }
 
+                // Trigger media control and hooks for "start" event
+                TriggerEvent("start", "Pomodoro", length);
+
                 // Show notification without requiring user interaction
                 ShowNonModalNotification("Starting Pomodoro", $"{length} minute Pomodoro session");
 
@@ -542,6 +740,9 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
                 {
                     length = customLength;
                 }
+
+                // Trigger media control and hooks for "start" event
+                TriggerEvent("start", "Short Break", length);
 
                 // Show notification without requiring user interaction
                 ShowNonModalNotification("Starting Break", $"{length} minute short break");
@@ -605,6 +806,9 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
                     length = customLength;
                 }
 
+                // Trigger media control and hooks for "start" event
+                TriggerEvent("start", "Long Break", length);
+
                 // Show notification without requiring user interaction
                 ShowNonModalNotification("Starting Long Break", $"{length} minute long break");
 
@@ -667,6 +871,10 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
                         if (success)
                         {
                             CurrentSession.IsPaused = true;
+
+                            // Trigger hooks for "pause" event
+                            TriggerEvent("pause", CurrentSession.Type, CurrentSession.LengthMinutes);
+
                             Context.API.ShowMsg("Timer Paused", $"{CurrentSession.Type} timer paused", IconPath);
                         }
                         else
@@ -710,6 +918,10 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
                         if (success)
                         {
                             CurrentSession.IsPaused = false;
+
+                            // Trigger hooks for "resume" event
+                            TriggerEvent("resume", CurrentSession.Type, CurrentSession.LengthMinutes);
+
                             Context.API.ShowMsg("Timer Resumed", $"{CurrentSession.Type} timer resumed", IconPath);
                         }
                         else
@@ -752,6 +964,9 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
                         var success = await ApiService.StopTimerAsync(CurrentSession.TimerId);
                         if (success)
                         {
+                            // Trigger hooks for "stop" event
+                            TriggerEvent("stop", CurrentSession.Type, CurrentSession.LengthMinutes);
+
                             string message = $"{CurrentSession.Type} timer stopped";
                             Context.API.ShowMsg("Timer Stopped", message, IconPath);
                             CurrentSession = null;

--- a/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/Main.cs
+++ b/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/Main.cs
@@ -123,7 +123,7 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
             new PluginAdditionalOption
             {
                 Key = nameof(MediaPlayOnSessionStart),
-                DisplayLabel = "▶ Play media on session start",
+                DisplayLabel = "▶ Toggle media on session start",
                 DisplayDescription = "Toggle play/pause on media (Spotify, YouTube, etc.) when a focus session starts",
                 PluginOptionType = PluginAdditionalOption.AdditionalOptionType.Checkbox,
                 Value = MediaPlayOnSessionStart
@@ -328,6 +328,31 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
             }
 
             return new List<Result>();
+        }
+
+        /// <summary>
+        /// Executes a named command directly (bypassing Query/Result pipeline).
+        /// Used by the timer window to ensure hooks and media controls fire on
+        /// pause/resume/stop — Query only constructs a Result whose Action is
+        /// never invoked when called from the window.
+        /// </summary>
+        /// <param name="command">Command name (pause, resume, stop, etc.).</param>
+        /// <param name="parameters">Optional arguments.</param>
+        /// <returns>True if the command was found and executed.</returns>
+        public bool ExecuteCommand(string command, string parameters = "")
+        {
+            if (_commands.TryGetValue(command, out var action))
+            {
+                try
+                {
+                    return action(parameters);
+                }
+                catch (Exception ex)
+                {
+                    Log.Exception($"Error executing command '{command}'", ex, GetType());
+                }
+            }
+            return false;
         }
 
         /// <summary>
@@ -676,9 +701,6 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
                     length = customLength;
                 }
 
-                // Trigger media control and hooks for "start" event
-                TriggerEvent("start", "Pomodoro", length);
-
                 // Show notification without requiring user interaction
                 ShowNonModalNotification("Starting Pomodoro", $"{length} minute Pomodoro session");
 
@@ -697,6 +719,9 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
                                 StartTime = DateTime.Now,
                                 EndTime = DateTime.Now.AddMinutes(length)
                             };
+
+                            // Trigger media control and hooks only after timer is confirmed
+                            TriggerEvent("start", "Pomodoro", length);
 
                             ShowPomodoroWindow(CurrentSession);
                         }
@@ -741,9 +766,6 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
                     length = customLength;
                 }
 
-                // Trigger media control and hooks for "start" event
-                TriggerEvent("start", "Short Break", length);
-
                 // Show notification without requiring user interaction
                 ShowNonModalNotification("Starting Break", $"{length} minute short break");
 
@@ -762,6 +784,9 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
                                 StartTime = DateTime.Now,
                                 EndTime = DateTime.Now.AddMinutes(length)
                             };
+
+                            // Trigger media control and hooks only after timer is confirmed
+                            TriggerEvent("start", "Short Break", length);
 
                             ShowPomodoroWindow(CurrentSession);
                         }
@@ -806,9 +831,6 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
                     length = customLength;
                 }
 
-                // Trigger media control and hooks for "start" event
-                TriggerEvent("start", "Long Break", length);
-
                 // Show notification without requiring user interaction
                 ShowNonModalNotification("Starting Long Break", $"{length} minute long break");
 
@@ -827,6 +849,9 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
                                 StartTime = DateTime.Now,
                                 EndTime = DateTime.Now.AddMinutes(length)
                             };
+
+                            // Trigger media control and hooks only after timer is confirmed
+                            TriggerEvent("start", "Long Break", length);
 
                             ShowPomodoroWindow(CurrentSession);
                         }

--- a/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/Models/PomodoroEvent.cs
+++ b/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/Models/PomodoroEvent.cs
@@ -1,0 +1,23 @@
+namespace Community.PowerToys.Run.Plugin.Pomodoro.Models
+{
+    /// <summary>
+    /// Represents a timer lifecycle event that can trigger media control and custom hooks.
+    /// </summary>
+    public class PomodoroEvent
+    {
+        /// <summary>
+        /// Gets or sets the event name: "start", "end", "pause", "resume", or "stop".
+        /// </summary>
+        public string EventName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the session type: "Pomodoro", "Short Break", or "Long Break".
+        /// </summary>
+        public string SessionType { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the session length in minutes.
+        /// </summary>
+        public int LengthMinutes { get; set; }
+    }
+}

--- a/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/Models/PomodoroSettings.cs
+++ b/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/Models/PomodoroSettings.cs
@@ -116,6 +116,56 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro.Models
         // Current pomodoro count in the cycle
         public int CurrentPomodoroCount { get; set; } = 0;
 
+        // ─── Media Control ───
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to toggle media play/pause on session start.
+        /// </summary>
+        public bool MediaPlayOnSessionStart { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to toggle media play/pause on session end.
+        /// </summary>
+        public bool MediaPauseOnSessionEnd { get; set; } = false;
+
+        // ─── CLI Hooks ───
+
+        /// <summary>
+        /// Gets or sets the CLI command to run when a Pomodoro session starts.
+        /// Tokens: {event}, {type}, {minutes}
+        /// </summary>
+        public string HookOnPomodoroStart { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the CLI command to run when a Pomodoro session ends.
+        /// </summary>
+        public string HookOnPomodoroEnd { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the CLI command to run when any break starts.
+        /// </summary>
+        public string HookOnBreakStart { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the CLI command to run when any break ends.
+        /// </summary>
+        public string HookOnBreakEnd { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the CLI command to run when the timer is paused.
+        /// </summary>
+        public string HookOnPause { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the CLI command to run when the timer is resumed.
+        /// </summary>
+        public string HookOnResume { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the CLI command to run when the timer is stopped manually.
+        /// </summary>
+        public string HookOnStop { get; set; } = string.Empty;
+
         /// <summary>
         /// Adds a timer duration to the recent list.
         /// </summary>

--- a/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/PomodoroResultWindow.xaml.cs
+++ b/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/PomodoroResultWindow.xaml.cs
@@ -591,14 +591,14 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
                 {
                     _session.IsPaused = false;
                     BtnPauseResume.Content = "Pause";
-                    _parent.Query(new Query("resume"));
+                    _parent.ExecuteCommand("resume");
                     UpdateTimeAfterResume();
                 }
                 else
                 {
                     _session.IsPaused = true;
                     BtnPauseResume.Content = "Resume";
-                    _parent.Query(new Query("pause"));
+                    _parent.ExecuteCommand("pause");
                 }
             }
             catch (Exception ex)
@@ -615,7 +615,7 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro
             try
             {
                 _timer.Stop();
-                _parent?.Query(new Query("stop"));
+                _parent?.ExecuteCommand("stop");
                 _isClosing = true;
                 Close();
             }

--- a/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/Services/HookService.cs
+++ b/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/Services/HookService.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Community.PowerToys.Run.Plugin.Pomodoro.Models;
+using Wox.Plugin.Logger;
+
+namespace Community.PowerToys.Run.Plugin.Pomodoro.Services
+{
+    /// <summary>
+    /// Executes arbitrary CLI commands (hooks) on Pomodoro timer events.
+    /// Users can define commands for session start, end, pause, resume, and stop,
+    /// separately for each session type (Pomodoro, Short Break, Long Break).
+    /// </summary>
+    public class HookService
+    {
+        private readonly Type _callingType;
+
+        /// <summary>
+        /// Placeholder variables that are replaced in command strings before execution.
+        /// </summary>
+        /// <remarks>
+        /// Available tokens:
+        /// <list type="bullet">
+        /// <item>{event} — the event name (start, end, pause, resume, stop)</item>
+        /// <item>{type} — the session type (Pomodoro, Short Break, Long Break)</item>
+        /// <item>{minutes} — the session length in minutes</item>
+        /// </list>
+        /// </remarks>
+        public HookService(Type callingType)
+        {
+            _callingType = callingType;
+        }
+
+        /// <summary>
+        /// Executes a hook command for the given event, if a command is configured.
+        /// Tokens in the command string are replaced with values from the event.
+        /// </summary>
+        /// <param name="command">The raw command string (may be null or empty).</param>
+        /// <param name="evt">The Pomodoro event details.</param>
+        public void ExecuteHook(string? command, PomodoroEvent evt)
+        {
+            if (string.IsNullOrWhiteSpace(command))
+                return;
+
+            try
+            {
+                string expanded = ExpandTokens(command, evt);
+
+                Log.Info($"Executing hook: {expanded}", _callingType);
+
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "cmd.exe",
+                    Arguments = $"/c {expanded}",
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true,
+                };
+
+                var process = new Process { StartInfo = psi };
+                process.Start();
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+                // Fire-and-forget: don't block the UI thread. The process runs
+                // asynchronously and we don't wait for its exit.
+            }
+            catch (Exception ex)
+            {
+                Log.Exception($"Error executing hook: {command}", ex, _callingType);
+            }
+        }
+
+        /// <summary>
+        /// Replaces placeholder tokens in the command string with event values.
+        /// </summary>
+        private static string ExpandTokens(string command, PomodoroEvent evt)
+        {
+            return command
+                .Replace("{event}", evt.EventName, StringComparison.OrdinalIgnoreCase)
+                .Replace("{type}", evt.SessionType ?? string.Empty, StringComparison.OrdinalIgnoreCase)
+                .Replace("{minutes}", evt.LengthMinutes.ToString(), StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/Services/HookService.cs
+++ b/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/Services/HookService.cs
@@ -9,7 +9,7 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro.Services
     /// <summary>
     /// Executes arbitrary CLI commands (hooks) on Pomodoro timer events.
     /// Users can define commands for session start, end, pause, resume, and stop,
-    /// separately for each session type (Pomodoro, Short Break, Long Break).
+    /// as well as dedicated break start/end hooks.
     /// </summary>
     public class HookService
     {
@@ -55,16 +55,18 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro.Services
                     UseShellExecute = false,
                     CreateNoWindow = true,
                     WindowStyle = ProcessWindowStyle.Hidden,
-                    RedirectStandardError = true,
-                    RedirectStandardOutput = true,
                 };
 
                 var process = new Process { StartInfo = psi };
+                process.EnableRaisingEvents = true;
+                process.Exited += (sender, _) =>
+                {
+                    try { ((Process)sender!).Dispose(); }
+                    catch (ObjectDisposedException) { /* already disposed */ }
+                };
                 process.Start();
-                process.BeginOutputReadLine();
-                process.BeginErrorReadLine();
-                // Fire-and-forget: don't block the UI thread. The process runs
-                // asynchronously and we don't wait for its exit.
+                // Fire-and-forget: don't block the UI thread. The process disposes
+                // itself on exit via the Exited handler to avoid leaking handles.
             }
             catch (Exception ex)
             {
@@ -75,6 +77,12 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro.Services
         /// <summary>
         /// Replaces placeholder tokens in the command string with event values.
         /// </summary>
+        /// <remarks>
+        /// Token values are derived from internal plugin state (event name, session type,
+        /// session length) and are NOT user-supplied runtime input. The command template
+        /// itself is authored by the user in plugin settings and intentionally executed
+        /// verbatim through cmd.exe, so shell metacharacters in the template are by design.
+        /// </remarks>
         private static string ExpandTokens(string command, PomodoroEvent evt)
         {
             return command

--- a/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/Services/MediaControlService.cs
+++ b/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/Services/MediaControlService.cs
@@ -97,7 +97,7 @@ namespace Community.PowerToys.Run.Plugin.Pomodoro.Services
         private void SendMediaKey(int keyCode)
         {
             keybd_event((byte)keyCode, 0, KEYEVENTF_EXTENDEDKEY, 0);
-            keybd_event((byte)keyCode, 0, KEYEVENTF_KEYUP, 0);
+            keybd_event((byte)keyCode, 0, KEYEVENTF_KEYUP | KEYEVENTF_EXTENDEDKEY, 0);
         }
     }
 }

--- a/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/Services/MediaControlService.cs
+++ b/Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/Services/MediaControlService.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Runtime.InteropServices;
+using Wox.Plugin.Logger;
+
+namespace Community.PowerToys.Run.Plugin.Pomodoro.Services
+{
+    /// <summary>
+    /// Controls system-wide media playback (play/pause) using Windows media keys.
+    /// Works with any media application that listens for media keys: Spotify,
+    /// YouTube (in browsers), Windows Media Player, foobar2000, etc.
+    /// </summary>
+    public class MediaControlService
+    {
+        private readonly Type _callingType;
+
+        // Virtual key codes for media keys
+        private const int VK_MEDIA_PLAY_PAUSE = 0xB3;
+        private const int VK_MEDIA_NEXT_TRACK = 0xB0;
+        private const int VK_MEDIA_PREV_TRACK = 0xB1;
+        private const int VK_MEDIA_STOP = 0xB2;
+
+        private const uint KEYEVENTF_EXTENDEDKEY = 0x0001;
+        private const uint KEYEVENTF_KEYUP = 0x0002;
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, nuint dwExtraInfo);
+
+        public MediaControlService(Type callingType)
+        {
+            _callingType = callingType;
+        }
+
+        /// <summary>
+        /// Toggles media play/pause (sends the media play/pause key).
+        /// </summary>
+        public void TogglePlayPause()
+        {
+            try
+            {
+                SendMediaKey(VK_MEDIA_PLAY_PAUSE);
+                Log.Info("Media play/pause toggled", _callingType);
+            }
+            catch (Exception ex)
+            {
+                Log.Exception("Error toggling media play/pause", ex, _callingType);
+            }
+        }
+
+        /// <summary>
+        /// Sends the media stop key.
+        /// </summary>
+        public void Stop()
+        {
+            try
+            {
+                SendMediaKey(VK_MEDIA_STOP);
+                Log.Info("Media stop sent", _callingType);
+            }
+            catch (Exception ex)
+            {
+                Log.Exception("Error stopping media", ex, _callingType);
+            }
+        }
+
+        /// <summary>
+        /// Sends the next track key.
+        /// </summary>
+        public void NextTrack()
+        {
+            try
+            {
+                SendMediaKey(VK_MEDIA_NEXT_TRACK);
+                Log.Info("Media next track sent", _callingType);
+            }
+            catch (Exception ex)
+            {
+                Log.Exception("Error sending next track", ex, _callingType);
+            }
+        }
+
+        /// <summary>
+        /// Sends the previous track key.
+        /// </summary>
+        public void PreviousTrack()
+        {
+            try
+            {
+                SendMediaKey(VK_MEDIA_PREV_TRACK);
+                Log.Info("Media previous track sent", _callingType);
+            }
+            catch (Exception ex)
+            {
+                Log.Exception("Error sending previous track", ex, _callingType);
+            }
+        }
+
+        private void SendMediaKey(int keyCode)
+        {
+            keybd_event((byte)keyCode, 0, KEYEVENTF_EXTENDEDKEY, 0);
+            keybd_event((byte)keyCode, 0, KEYEVENTF_KEYUP, 0);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Pomodoro is a plugin for [Microsoft PowerToys Run](https://github.com/microsoft/
 - ⚙️ **Configurable Session Length** - Customize work and break durations to fit your workflow
 - 🪟 **Resizable & Minimizable Timer Window** - Resize the timer window with the corner grip, minimize it to the taskbar, and it remembers your preferred size and position between sessions
 - 🎵 **Media Control** - Automatically play/pause media (Spotify, YouTube, etc.) when sessions start and end
-- 🪝 **CLI Hooks** - Run arbitrary CLI commands on timer events (start, end, pause, resume, stop)
+- 🪝 **CLI Hooks** - Run arbitrary CLI commands on timer events (start, end, pause, resume, stop), including dedicated break start/end hooks
 
 ## 🎬 Demo Gallery
 
@@ -290,34 +290,34 @@ Command strings support the following tokens, which are replaced with event deta
 
 ```
 # On break start — turn lights on
-hookOnBreakStart: hue lights on --brightness 100
+HookOnBreakStart: hue lights on --brightness 100
 
 # On Pomodoro start — dim lights for focus
-hookOnPomodoroStart: hue lights dim --brightness 30
+HookOnPomodoroStart: hue lights dim --brightness 30
 ```
 
 #### Time Tracking (Toggl)
 
 ```
 # On Pomodoro start — start a Toggl timer
-hookOnPomodoroStart: toggl start --description "Pomodoro ({minutes} min)"
+HookOnPomodoroStart: toggl start --description "Pomodoro ({minutes} min)"
 
 # On Pomodoro end — stop the Toggl timer
-hookOnPomodoroEnd: toggl stop
+HookOnPomodoroEnd: toggl stop
 ```
 
 #### Desktop Notification (BurntToast PowerShell)
 
 ```
 # On Pomodoro end
-hookOnPomodoroEnd: powershell -Command "New-BurntToastNotification -Text 'Pomodoro Complete!', 'Time for a break.'"
+HookOnPomodoroEnd: powershell -Command "New-BurntToastNotification -Text 'Pomodoro Complete!', 'Time for a break.'"
 ```
 
 #### Custom Sound
 
 ```
 # On break start — play a custom sound
-hookOnBreakStart: powershell -Command "(New-Object Media.SoundPlayer 'C:\Sounds\chime.wav').PlaySync()"
+HookOnBreakStart: powershell -Command "(New-Object Media.SoundPlayer 'C:\Sounds\chime.wav').PlaySync()"
 ```
 
 > **Note:** Hooks are executed via `cmd.exe /c <command>` in a hidden window, fire-and-forget (the plugin does not wait for them to complete).

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Pomodoro is a plugin for [Microsoft PowerToys Run](https://github.com/microsoft/
 - 🌙 **Break Management** - Automatically switch between work sessions and breaks
 - ⚙️ **Configurable Session Length** - Customize work and break durations to fit your workflow
 - 🪟 **Resizable & Minimizable Timer Window** - Resize the timer window with the corner grip, minimize it to the taskbar, and it remembers your preferred size and position between sessions
+- 🎵 **Media Control** - Automatically play/pause media (Spotify, YouTube, etc.) when sessions start and end
+- 🪝 **CLI Hooks** - Run arbitrary CLI commands on timer events (start, end, pause, resume, stop)
 
 ## 🎬 Demo Gallery
 
@@ -236,6 +238,90 @@ Please make sure to update tests as appropriate.
 <p>Yes, this feature is available in the plugin. Your completed sessions are tracked and can be viewed through the plugin interface.</p>
 </details>
 
+## 🎵 Media Control
+
+The plugin can automatically control media playback (play/pause) when your focus sessions start and end. This works with **any** application that responds to Windows media keys — Spotify, YouTube (in your browser), Windows Media Player, foobar2000, and more.
+
+### Enable Media Control
+
+Open PowerToys Settings → PowerToys Run → Plugins → Pomodoro:
+
+| Setting | Description |
+|---------|-------------|
+| **▶ Play media on session start** | Toggles play/pause when a **Pomodoro** (focus) session starts |
+| **⏸ Pause media on session end** | Toggles play/pause when a **Pomodoro** (focus) session ends |
+
+> **Note:** Media control only triggers for **Pomodoro** (focus) sessions, not for breaks. This way your music starts when you begin working and pauses when your focus session is over — exactly the behavior described in [issue #2](https://github.com/ruslanlap/PowerToysRun-Pomodoro/issues/2).
+
+## 🪝 CLI Hooks (Advanced)
+
+For power users, the plugin can run **arbitrary CLI commands** on timer lifecycle events. This enables integrations like:
+
+- 🏠 **Smart home**: Turn lights on during breaks, dim them during focus
+- 📊 **Time tracking**: Log sessions to Toggl, Clockify, or a spreadsheet
+- 🔔 **Notifications**: Send a Slack/Discord/Teams message when sessions end
+- 🎵 **Custom media control**: Use `nircmd` or AutoHotkey for advanced media management
+
+### Hook Events
+
+| Event | Trigger | Setting Key |
+|-------|---------|-------------|
+| **Pomodoro Start** | When a Pomodoro focus session begins | `HookOnPomodoroStart` |
+| **Pomodoro End** | When a Pomodoro focus session completes | `HookOnPomodoroEnd` |
+| **Break Start** | When any break (short or long) begins | `HookOnBreakStart` |
+| **Break End** | When any break completes | `HookOnBreakEnd` |
+| **Pause** | When the timer is paused | `HookOnPause` |
+| **Resume** | When the timer is resumed | `HookOnResume` |
+| **Stop** | When the timer is manually stopped | `HookOnStop` |
+
+### Token Replacement
+
+Command strings support the following tokens, which are replaced with event details before execution:
+
+| Token | Description | Example value |
+|-------|-------------|---------------|
+| `{event}` | Event name | `start`, `end`, `pause`, `resume`, `stop` |
+| `{type}` | Session type | `Pomodoro`, `Short Break`, `Long Break` |
+| `{minutes}` | Session length in minutes | `25` |
+
+### Hook Examples
+
+#### Smart Lights (Hue CLI)
+
+```
+# On break start — turn lights on
+hookOnBreakStart: hue lights on --brightness 100
+
+# On Pomodoro start — dim lights for focus
+hookOnPomodoroStart: hue lights dim --brightness 30
+```
+
+#### Time Tracking (Toggl)
+
+```
+# On Pomodoro start — start a Toggl timer
+hookOnPomodoroStart: toggl start --description "Pomodoro ({minutes} min)"
+
+# On Pomodoro end — stop the Toggl timer
+hookOnPomodoroEnd: toggl stop
+```
+
+#### Desktop Notification (BurntToast PowerShell)
+
+```
+# On Pomodoro end
+hookOnPomodoroEnd: powershell -Command "New-BurntToastNotification -Text 'Pomodoro Complete!', 'Time for a break.'"
+```
+
+#### Custom Sound
+
+```
+# On break start — play a custom sound
+hookOnBreakStart: powershell -Command "(New-Object Media.SoundPlayer 'C:\Sounds\chime.wav').PlaySync()"
+```
+
+> **Note:** Hooks are executed via `cmd.exe /c <command>` in a hidden window, fire-and-forget (the plugin does not wait for them to complete).
+
 ## ✨ Why You'll Love Pomodoro Plugin
 
 - **Helps Maintain Focus**: Structure your work with dedicated focus periods
@@ -276,6 +362,8 @@ The plugin implements several PowerToys Run interfaces:
 
 ### Roadmap
 
+- [x] Media control (play/pause on session start/end) — [#2](https://github.com/ruslanlap/PowerToysRun-Pomodoro/issues/2)
+- [x] CLI hooks for custom integrations — [#2](https://github.com/ruslanlap/PowerToysRun-Pomodoro/issues/2)
 - [ ] Custom notification sounds
 - [ ] Weekly productivity analytics
 - [ ] Task labeling for Pomodoro sessions


### PR DESCRIPTION
Closes #2

## Summary

Implements both features requested in #2:
1. **Media control** — automatically play/pause media (Spotify, YouTube, etc.) when Pomodoro sessions start/end
2. **CLI hooks** — run arbitrary CLI commands on any timer lifecycle event

## 🎵 Media Control

Uses Windows media keys (VK_MEDIA_PLAY_PAUSE) via P/Invoke to toggle play/pause on any application that listens for media keys.

| Setting | Behavior |
|---------|----------|
| `MediaPlayOnSessionStart` | Toggles play/pause when a Pomodoro (focus) session starts |
| `MediaPauseOnSessionEnd` | Toggles play/pause when a Pomodoro (focus) session ends |

Works with: Spotify, YouTube (browser), Windows Media Player, foobar2000, and any app that responds to media keys.

## 🪝 CLI Hooks

Run arbitrary commands on 7 timer events:

| Event | When | Setting |
|-------|------|---------|
| Pomodoro Start | Focus session begins | `HookOnPomodoroStart` |
| Pomodoro End | Focus session completes | `HookOnPomodoroEnd` |
| Break Start | Any break begins | `HookOnBreakStart` |
| Break End | Any break completes | `HookOnBreakEnd` |
| Pause | Timer paused | `HookOnPause` |
| Resume | Timer resumed | `HookOnResume` |
| Stop | Timer manually stopped | `HookOnStop` |

### Token Expansion
```
{event}   → start | end | pause | resume | stop
{type}    → Pomodoro | Short Break | Long Break
{minutes} → session length (e.g. 25)
```

### Example Use Cases
- **Smart lights**: `hue lights on` on break start, `hue lights dim` on Pomodoro start
- **Time tracking**: `toggl start --description "Pomodoro ({minutes} min)"` on Pomodoro start
- **Notifications**: `powershell -Command "New-BurntToastNotification ..."` on Pomodoro end
- **Custom sounds**: play a WAV file on break start

Hooks are fire-and-forget, executed via `cmd.exe /c` in a hidden window.

## Files Changed

| File | Change |
|------|--------|
| `Models/PomodoroEvent.cs` | **New** — event data model |
| `Services/MediaControlService.cs` | **New** — media key control via P/Invoke |
| `Services/HookService.cs` | **New** — CLI command execution with token expansion |
| `Models/PomodoroSettings.cs` | Added 9 new settings (2 media + 7 hooks) |
| `Main.cs` | Wired services, added `TriggerEvent()`, added 9 AdditionalOptions, updated `UpdateSettings()` |
| `MainTests.cs` | Tests for new options + HookService + PomodoroEvent |
| `README.md` | Full documentation with examples |

## Test plan

- [ ] Build succeeds on Windows (`dotnet build Pomodoro/Pomodoro.sln`)
- [ ] Unit tests pass
- [ ] Enable "Play media on session start" → start Pomodoro → Spotify/YouTube starts playing
- [ ] Enable "Pause media on session end" → Pomodoro completes → media pauses
- [ ] Set `HookOnPomodoroStart` to a test command → verify it executes when Pomodoro starts
- [ ] Verify token expansion: `echo {event} {type} {minutes} > %TEMP%\hook-test.txt`
- [ ] Verify hooks fire on all 7 events (start, end, pause, resume, stop, break start/end)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ruslanlap/powertoysrun-pomodoro/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->