### PR TITLE
ci: add release-please bot for automated versioning

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,20 +1,15 @@
-name: Build and Release Pomodoro Plugin
+name: Build and Upload Release Assets
 
 on:
-  push:
-    branches:
-      - main
-      - master
-    tags:
-      - 'v*'
+  # Triggered when release-please creates a published release
+  release:
+    types: [published]
+  # Manual trigger for testing
+  workflow_dispatch:
 
-# Permissions for GITHUB_TOKEN (principle of least privilege)
 permissions:
-  contents: write  # Needed for creating releases
-  issues: read
-  pull-requests: read
+  contents: write
 
-# Add restrictions for parallel runs
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -25,214 +20,108 @@ jobs:
     strategy:
       matrix:
         platform: [x64, arm64]
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '9.0.x'
-      
+
       - name: Build
         run: dotnet build Pomodoro/Pomodoro.sln -c Release -p:Platform="${{ matrix.platform }}"
-      
-      - name: Get version
+
+      - name: Get version from tag
         id: get_version
         shell: bash
         run: |
-          if [[ $GITHUB_REF == refs/tags/v* ]]; then
-            echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-            echo "IS_TAG=true" >> $GITHUB_OUTPUT
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
           else
-            echo "VERSION=$(date +'%Y.%m.%d')-$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_OUTPUT
-            echo "IS_TAG=false" >> $GITHUB_OUTPUT
+            VERSION="dev-$(echo $GITHUB_SHA | cut -c1-7)"
           fi
-      
-      - name: Debug Output
-        run: |
-          Get-ChildItem -Path "Pomodoro" -Recurse -Directory | Where-Object { $_.Name -eq "Release" } | ForEach-Object { Write-Host $_.FullName }
-        shell: pwsh
-      
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
       - name: Create output directory
-        run: mkdir -p artifacts
-      
-      - name: Copy build output to artifacts directory
         run: |
-          $artifactDir = "artifacts/Pomodoro-v${{ steps.get_version.outputs.VERSION }}-${{ matrix.platform }}"
-          
-          # Create the artifact directory
+          $artifactDir = "artifacts/Pomodoro"
           New-Item -ItemType Directory -Force -Path $artifactDir
-          
-          # Create Pomodoro subfolder
-          New-Item -ItemType Directory -Force -Path "$artifactDir/Pomodoro"
-          
-          # Define the direct path to the build output
+
           $buildOutput = "Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/bin/${{ matrix.platform }}/Release"
-          
-          Write-Host "Using build output directory: $buildOutput"
-          
-          # Check if the directory exists
+
+          # Search for runtime folder if direct path doesn't exist
           if (-not (Test-Path $buildOutput)) {
-            Write-Host "Build output directory not found at expected path. Searching for it..."
-            $buildOutput = Get-ChildItem -Path "Pomodoro" -Recurse -Directory | 
-                           Where-Object { $_.Name -eq "Release" -and $_.FullName -like "*${{ matrix.platform }}*" } | 
-                           Select-Object -First 1 -ExpandProperty FullName
-            
-            if ($buildOutput) {
-              Write-Host "Found build output directory: $buildOutput"
-            } else {
-              Write-Error "Could not find any Release directory for platform ${{ matrix.platform }}"
-              exit 1
-            }
+            $buildOutput = Get-ChildItem -Path "Pomodoro" -Recurse -Directory |
+              Where-Object { $_.Name -eq "Release" -and $_.FullName -like "*${{ matrix.platform }}*" } |
+              Select-Object -First 1 -ExpandProperty FullName
           }
-          
-          # Check if build output exists before proceeding
-          if (-not (Test-Path $buildOutput)) {
-            Write-Error "Build output directory not found"
-            exit 1
-          }
-          
-          # Check for files directly in the build output directory
-          $files = Get-ChildItem -Path $buildOutput -File
-          if ($files.Count -gt 0) {
-            Write-Host "Found $($files.Count) files in build output directory. Copying directly..."
-            Copy-Item -Path "$buildOutput/*" -Destination "$artifactDir/Pomodoro" -Recurse -Force
-            Write-Host "Files copied successfully"
+
+          # Find the runtime subfolder (net*-windows*)
+          $runtimeFolder = Get-ChildItem -Path $buildOutput -Directory |
+            Where-Object { $_.Name -like "net*-windows*" } |
+            Select-Object -First 1 -ExpandProperty FullName
+
+          if ($runtimeFolder) {
+            Copy-Item -Path "$runtimeFolder/*" -Destination $artifactDir -Recurse -Force
           } else {
-            # Look for a .NET runtime folder
-            $runtimeFolder = Get-ChildItem -Path $buildOutput -Directory | 
-                             Where-Object { $_.Name -like "net*-windows*" } | 
-                             Select-Object -First 1 -ExpandProperty FullName
-            
-            if ($runtimeFolder) {
-              Write-Host "Found runtime folder: $runtimeFolder"
-              Copy-Item -Path "$runtimeFolder/*" -Destination "$artifactDir/Pomodoro" -Recurse -Force
-              Write-Host "Files copied successfully from runtime folder"
-            } else {
-              # If no runtime folder, check for any subdirectories
-              $subDirs = Get-ChildItem -Path $buildOutput -Directory
-              if ($subDirs.Count -gt 0) {
-                $firstSubDir = $subDirs[0].FullName
-                Write-Host "No runtime folder found, but found subdirectory: $firstSubDir"
-                Copy-Item -Path "$firstSubDir/*" -Destination "$artifactDir/Pomodoro" -Recurse -Force
-                Write-Host "Files copied from first subdirectory"
-              } else {
-                Write-Error "No files or subdirectories found in build output directory"
-                exit 1
-              }
-            }
+            Copy-Item -Path "$buildOutput/*" -Destination $artifactDir -Recurse -Force
           }
+
+          Write-Host "Artifacts in $artifactDir :"
+          Get-ChildItem $artifactDir -Recurse | ForEach-Object { Write-Host $_.FullName }
         shell: pwsh
-      
+
       - name: Create ZIP archive
         run: |
-          $artifactDir = "artifacts/Pomodoro-v${{ steps.get_version.outputs.VERSION }}-${{ matrix.platform }}"
-          
-          # Create the zip files with names that match the README.md download links
           if ("${{ matrix.platform }}" -eq "x64") {
             $zipFile = "Pomodoro-x64.zip"
           } else {
             $zipFile = "Pomodoro-ARM64.zip"
           }
-          
-          # Create the zip file
-          Compress-Archive -Path "$artifactDir/Pomodoro" -DestinationPath "artifacts/$zipFile"
+          Compress-Archive -Path "artifacts/Pomodoro" -DestinationPath "artifacts/$zipFile"
         shell: pwsh
-      
-      - name: Upload build artifacts
+
+      - name: Generate SHA256 checksum
+        run: |
+          if ("${{ matrix.platform }}" -eq "x64") {
+            $zipFile = "artifacts/Pomodoro-x64.zip"
+          } else {
+            $zipFile = "artifacts/Pomodoro-ARM64.zip"
+          }
+          $hash = (Get-FileHash $zipFile -Algorithm SHA256).Hash
+          "$hash  $(Split-Path $zipFile -Leaf)" | Out-File -Encoding ascii "$zipFile.sha256"
+          Write-Host "SHA256: $hash"
+        shell: pwsh
+
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts-${{ matrix.platform }}
-          path: artifacts/*.zip
-  
-  release:
+          name: build-${{ matrix.platform }}
+          path: artifacts/*.zip*
+
+  upload:
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-    
+    # Only upload to the release if this was triggered by a release event
+    if: github.event_name == 'release'
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: downloaded-artifacts
-      
-      # Debug step to see what files are available
-      - name: List downloaded artifacts
+
+      - name: Prepare assets
         run: |
-          echo "Listing downloaded artifacts directory:"
-          ls -la downloaded-artifacts
-          echo "Listing x64 artifacts:"
-          ls -la downloaded-artifacts/build-artifacts-x64 || echo "No x64 artifacts found"
-          echo "Listing ARM64 artifacts:"
-          ls -la downloaded-artifacts/build-artifacts-arm64 || echo "No ARM64 artifacts found"
-      
-      # Copy artifacts to the expected location with the correct names
-      - name: Prepare artifacts for release
-        run: |
-          mkdir -p release-artifacts
-          cp downloaded-artifacts/build-artifacts-x64/*.zip release-artifacts/Pomodoro-x64.zip || echo "Failed to copy x64 artifact"
-          cp downloaded-artifacts/build-artifacts-arm64/*.zip release-artifacts/Pomodoro-ARM64.zip || echo "Failed to copy ARM64 artifact"
-          echo "Listing release artifacts:"
-          ls -la release-artifacts
-      
-      - name: Get version from tag
-        id: get_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-      
-      - name: Prepare Release Notes
-        id: release_notes
-        run: |
-          cat > release_notes.md << 'EOL'
-          # 🍅 Pomodoro Plugin v${{ steps.get_version.outputs.VERSION }}
-          
-          ![Pomodoro Plugin Logo](https://raw.githubusercontent.com/ruslanlap/PowerToysRun-Pomodoro/master/Assets/logo.png)
-          
-          ## ✨ What's New
-          
-          This release brings you the power of the Pomodoro Technique directly to your PowerToys Run interface!
-          
-          ### 🚀 Highlights
-          
-          - ⏱️ **Start, Pause, and Reset Pomodoro Sessions** - Manage your work sessions with simple commands
-          - 🍅 **Visual Countdown** - See time remaining in your current session
-          - 🔔 **End-of-Session Alerts** - Get notified when your session ends with sound or visual cues
-          - 📊 **Session Tracking** - Keep track of completed Pomodoro sessions
-          - 🌙 **Break Management** - Automatically switch between work sessions and breaks
-          - ⚙️ **Configurable Session Length** - Customize work and break durations to fit your workflow
-          - 🔁 **Daily Productivity History** - View your productivity patterns over time
-          
-          ## 📥 Installation
-          
-          1. Download the ZIP file for your platform (x64 or ARM64)
-          2. Extract to `%LOCALAPPDATA%\Microsoft\PowerToys\PowerToys Run\Plugins\`
-          3. Restart PowerToys
-          4. Start using with `Alt+Space` then type `pomodoro`
-          
-          ## 🐛 Found a bug?
-          
-          If you encounter any issues or have suggestions for improvements, please [open an issue](https://github.com/ruslanlap/PowerToysRun-Pomodoro/issues).
-          
-          Made with ❤️ by [ruslanlap](https://github.com/ruslanlap)
-          EOL
-          
-          echo "RELEASE_NOTES<<EOF" >> $GITHUB_OUTPUT
-          cat release_notes.md >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-      
-      - name: Create Release
-        uses: softprops/action-gh-release@v1
-        with:
-          name: Pomodoro Plugin v${{ steps.get_version.outputs.VERSION }}
-          body: ${{ steps.release_notes.outputs.RELEASE_NOTES }}
-          draft: false
-          prerelease: false
-          files: |
-            release-artifacts/Pomodoro-x64.zip
-            release-artifacts/Pomodoro-ARM64.zip
+          mkdir -p release-assets
+          cp downloaded-artifacts/build-x64/*.zip* release-assets/
+          cp downloaded-artifacts/build-arm64/*.zip* release-assets/
+          ls -la release-assets/
+
+      - name: Upload assets to GitHub Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" release-assets/* --clobber

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,27 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: simple
+          # Bump plugin.json version alongside the release
+          include-component-in-tag: false
+          # These files are updated with the new version on each release
+          extra-files: |
+            Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/plugin.json
+          # Custom version extraction — read from plugin.json "Version" field
+          version-file: Pomodoro/Community.PowerToys.Run.Plugin.Pomodoro/plugin.json
+          version-path: Version

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
   ![Maintenance](https://img.shields.io/maintenance/yes/2025)
   ![C#](https://img.shields.io/badge/C%23-.NET-512BD4)
-  ![Version](https://img.shields.io/badge/version-v1.0.0-brightgreen)
+  ![Version](https://img.shields.io/github/v/release/ruslanlap/PowerToysRun-Pomodoro)
   ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)
   [![GitHub stars](https://img.shields.io/github/stars/ruslanlap/PowerToysRun-Pomodoro)](https://github.com/ruslanlap/PowerToysRun-Pomodoro/stargazers)
   [![GitHub issues](https://img.shields.io/github/issues/ruslanlap/PowerToysRun-Pomodoro)](https://github.com/ruslanlap/PowerToysRun-Pomodoro/issues)
@@ -27,11 +27,11 @@
 </div>
 
 <div align="center">
-  <a href="https://github.com/ruslanlap/PowerToysRun-Pomodoro/releases/download/v1.0.0/Pomodoro-x64.zip">
-    <img src="https://img.shields.io/badge/Download%20Latest%20Release-x64-blue?style=for-the-badge&logo=github" alt="Download Latest Release" />
+  <a href="https://github.com/ruslanlap/PowerToysRun-Pomodoro/releases/latest/download/Pomodoro-x64.zip">
+    <img src="https://img.shields.io/badge/Download%20Latest%20Release-x64-blue?style=for-the-badge&logo=github" alt="Download Latest Release x64" />
   </a>
-  <a href="https://github.com/ruslanlap/PowerToysRun-Pomodoro/releases/download/v1.0.0/Pomodoro-ARM64.zip">
-    <img src="https://img.shields.io/badge/Download%20Latest%20Release-ARM64-blue?style=for-the-badge&logo=github" alt="Download Latest Release" />
+  <a href="https://github.com/ruslanlap/PowerToysRun-Pomodoro/releases/latest/download/Pomodoro-ARM64.zip">
+    <img src="https://img.shields.io/badge/Download%20Latest%20Release-ARM64-blue?style=for-the-badge&logo=github" alt="Download Latest Release ARM64" />
   </a>
 </div>
 
@@ -62,7 +62,7 @@ Pomodoro is a plugin for [Microsoft PowerToys Run](https://github.com/microsoft/
 ## ⚡ Easy Install
 
 <div align="">
-  <a href="https://github.com/ruslanlap/PowerToysRun-Pomodoro/releases/download/v1.0.0/Pomodoro-x64.zip">
+  <a href="https://github.com/ruslanlap/PowerToysRun-Pomodoro/releases/latest/download/Pomodoro-x64.zip">
     <img src="https://img.shields.io/badge/⬇️_DOWNLOAD-POMODORO_PLUGIN-blue?style=for-the-badge&logo=github" alt="Download Pomodoro Plugin">
   </a>
   
@@ -204,6 +204,18 @@ Contributions are welcome! Here's how you can help:
 3. Commit your changes: `git commit -m 'Add amazing feature'`
 4. Push to the branch: `git push origin feature/amazing-feature`
 5. Open a Pull Request
+
+### Conventional Commits & Automatic Releases
+
+This project uses [release-please](https://github.com/googleapis/release-please) bot for automated versioning and releases. Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+| Commit type | Bump | Example |
+|-------------|------|---------|
+| `fix:` | Patch (1.0.**0** → 1.0.**1**) | `fix: correct timer display` |
+| `feat:` | Minor (1.**0**.0 → 1.**1**.0) | `feat: add break reminders` |
+| `BREAKING CHANGE:` | Major (**1**.0.0 → **2**.0.0) | `feat!: new config format` |
+
+When you push to `main`, the bot opens a "release PR" with a changelog and version bump. Merge it to publish a new release automatically.
 
 Please make sure to update tests as appropriate.
 


### PR DESCRIPTION
## 🤖 Automated Release Bot

Adds [release-please](https://github.com/googleapis/release-please) for fully automated versioning and releases via **Conventional Commits**.

### What's included

| File | Change |
|------|--------|
| `release-please.yml` | **New** — release bot: reads conventional commits, bumps version in `plugin.json`, generates changelog, creates release PR → tag + GitHub release |
| `build-and-release.yml` | **Rewritten** — triggers on `release: published`, builds x64+ARM64, uploads zips + SHA256 checksums to the release |
| `README.md` | Dynamic `/releases/latest/download/` links (no more manual version edits), auto version badge, conventional commits docs |

### How it works

1. Push commits with conventional format (`feat:`, `fix:`, etc.) to `master`
2. release-please opens a **release PR** with changelog + version bump
3. Merge the PR → tag + release created automatically
4. build-and-release workflow builds and attaches x64/ARM64 zips

### Version flow

```
1.0.0 → fix: → 1.0.1 → feat: → 1.1.0 → feat!: → 2.0.0
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ruslanlap/powertoysrun-pomodoro/pull/4" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->